### PR TITLE
update term_page_manager.py

### DIFF
--- a/.github/workflows/update_metadata_dictionary.yml
+++ b/.github/workflows/update_metadata_dictionary.yml
@@ -52,7 +52,7 @@ jobs:
           python term_page_manager.py
       
       - name: update term pages if term_page_manager.py is changed
-        if: contains(steps.changed-files.outputs.modified_files, 'term_file_manager.py')
+        if: contains(steps.changed-files.outputs.modified_files, 'term_page_manager.py')
         run: |
           python term_page_manager.py
       

--- a/docs/NGS/libraryPrep.md
+++ b/docs/NGS/libraryPrep.md
@@ -10,7 +10,7 @@ title: libraryPrep
 {: .note-title } 
 >libraryPrep
 >
->The general strategy by which the library was prepared [[Source]](nan)
+>The general strategy by which the library was prepared [[Source]](https://sagebionetworks.org/)
 <table id="myTable" class="display" style="width:100%">
     <thead>
     {% for column in mydata[0] %}

--- a/term_page_manager.py
+++ b/term_page_manager.py
@@ -137,7 +137,7 @@ def generate_page(data_model, term_path):
     file = fileutils.MarkDownFile(f"docs/{post.metadata['parent']}/{term}")
     # add content to the file
     file.append_end(frontmatter.dumps(post))
-    print("\033[92m {} \033[00m".format(f"added docs/{term_path}.md"))
+    print("\033[92m {} \033[00m".format(f"added or modified docs/{term_path}.md"))
 
 def delete_page(page):
     """
@@ -188,13 +188,13 @@ def main():
     if not file_split[1] == file_split[2]:
       term_pages.append(f"{file_split[1]}/{file_split[2]}")
   
-  to_add = np.setdiff1d(term_files, term_pages).tolist()
   to_delete = np.setdiff1d(term_pages, term_files).tolist()
   list(map(delete_page, to_delete))
   
-  # generate pages for terms with the term files
+  # generate pages for new terms and rewrite existing pages so that any descriptions 
+  # in the model will be pushed to the dictionary site
   generate_page_temp = partial(generate_page, data_model)
-  list(map(generate_page_temp, to_add))
+  list(map(generate_page_temp, term_files))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
to rewrite all existing pages in case model descriptions or have changed.

I may be wrong but prior to this merge`term_page_manager.py` will only generate *new* pages (.md files). Although the action is setup such that this script will run if any of the `_data/*/*.csv` files change, the way the code was setup appeared to me to not incorporate model changes into the `md` files. This PR will make it so that `term_page_manager.py` not only creates new md files/pages for new terms/attributes, but will also regenerate existing pages so that the md `description` and `source` are updated with any changes in the model.